### PR TITLE
gitignore: Add local compiled binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # Build directories
 dist/
+
+# Compiled binary
+snab


### PR DESCRIPTION
If i compile the binary in the local folder, git says, I have a dirty working tree.